### PR TITLE
Close second Windows file handle blocking log rename after rollover

### DIFF
--- a/src/openhound/core/logging.py
+++ b/src/openhound/core/logging.py
@@ -230,6 +230,13 @@ class CustomLogger:
         return resolved_spec_path
 
     @staticmethod
+    def _close_handlers(logger: logging.Logger) -> None:
+        """Remove and close all handlers attached directly to a logger."""
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+            handler.close()
+
+    @staticmethod
     def default_platform_path() -> Path:
         """Get the default log path based on platform
 
@@ -260,7 +267,7 @@ class CustomLogger:
         log_file_path = self.base_path / f"ext_{name}.log"
         valid_path = self._is_valid_path(self.base_path, log_file_path)
         self.dlt_logger.setLevel(self.root_logger.level)
-        self.dlt_logger.handlers.clear()
+        self._close_handlers(self.dlt_logger)
         self.handlers[self.runtime_mode](self.dlt_logger, valid_path)
         self.dlt_logger.propagate = False
 
@@ -293,14 +300,14 @@ class CustomLogger:
         self.backup_count = dlt_backup_count if dlt_backup_count else self.backup_count
         self.interval = dlt_interval if dlt_interval else self.interval
 
-        # Clear the default DLT log handlers and set our own handlers based on the runtime mode
-        self.dlt_logger.handlers.clear()
-        self.handlers[self.runtime_mode](self.dlt_logger, self.log_file_path)
-        self.dlt_logger.propagate = False
+        # The root logger owns the default OpenHound file handler. DLT logs propagate
+        # there until set_handler routes them to an extension-specific log file.
+        self._close_handlers(self.dlt_logger)
+        self.dlt_logger.setLevel(getattr(logging, self.level))
+        self.dlt_logger.propagate = True
 
-        # Set the root logger level and handlers based on the runtime mode
         self.root_logger.setLevel(getattr(logging, self.level))
-        self.root_logger.handlers.clear()
+        self._close_handlers(self.root_logger)
         self.handlers[self.runtime_mode](self.root_logger, self.log_file_path)
 
     def container_handlers(self, logger: logging.Logger, file_path: Path) -> None:

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -4,6 +4,14 @@ import logging
 from openhound.core.logging import RotatingFileHandler, logger_override
 
 
+def _rotating_handlers(logger: logging.Logger) -> list[RotatingFileHandler]:
+    return [
+        handler
+        for handler in logger.handlers
+        if isinstance(handler, RotatingFileHandler)
+    ]
+
+
 def test_root_handler_setup():
     """Test that the root logger has a handler configured and that it is a RotatingFileHandler"""
     root_logger = logging.getLogger()
@@ -11,31 +19,35 @@ def test_root_handler_setup():
         "The root logger should have at least one handler configured"
     )
 
-    base_handler = root_logger.handlers[0]
-    assert isinstance(base_handler, RotatingFileHandler), (
+    rotating_handlers = _rotating_handlers(root_logger)
+    assert len(rotating_handlers) == 1, (
         "The root logger should use RotatingFileHandler"
     )
+    base_handler = rotating_handlers[0]
     assert base_handler.baseFilename.endswith("openhound.log"), (
         "The root logger should log to 'openhound.log'"
     )
 
 
-def test_dlt_handler_setup():
-    """Test that the default DLT handler is overwritten by our RotatingFileHandler"""
+def test_dlt_handler_setup(tmp_path):
+    """Test that default DLT logs propagate to the root OpenHound handler."""
+    logger_override.base_path = tmp_path
+    logger_override.setup()
+
     dlt_logger = logging.getLogger("dlt")
-    assert len(dlt_logger.handlers) > 0, (
-        "The default DLT logger should have at least one handler configured"
+    assert len(dlt_logger.handlers) == 0, (
+        "The default DLT logger should not own a separate file handler"
     )
-    assert dlt_logger.propagate is False, (
-        "The DLT logger should have propagation disabled to prevent duplicate logs in the root logger"
+    assert dlt_logger.propagate is True, (
+        "The DLT logger should propagate to the root OpenHound handler"
     )
 
-    base_handler = dlt_logger.handlers[0]
-    assert isinstance(base_handler, RotatingFileHandler), (
-        "The default DLT logger should use RotatingFileHandler"
+    root_handlers = _rotating_handlers(logging.getLogger())
+    assert len(root_handlers) == 1, (
+        "Only the root logger should own the default OpenHound file handler"
     )
-    assert base_handler.baseFilename.endswith("openhound.log"), (
-        "The default DLT logger should log to 'openhound.log'"
+    assert root_handlers[0].baseFilename.endswith("openhound.log"), (
+        "Default DLT logs should flow to 'openhound.log'"
     )
 
 


### PR DESCRIPTION
Fix proposed by Codex and tested on Windows 11, Python 3.14.

```
--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\domainadmin\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\logging\handlers.py", line 80, in emit
    self.doRollover()
    ~~~~~~~~~~~~~~~^^
  File "C:\Users\domainadmin\Desktop\ohsccm\OpenHound\src\openhound\core\logging.py", line 118, in doRollover
    super().doRollover()
    ~~~~~~~~~~~~~~~~~~^^
  File "C:\Users\domainadmin\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\logging\handlers.py", line 456, in doRollover
    self.rotate(self.baseFilename, dfn)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\domainadmin\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\logging\handlers.py", line 121, in rotate
    os.rename(source, dest)
    ~~~~~~~~~^^^^^^^^^^^^^^
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\domainadmin\\AppData\\Local\\openhound\\logs\\openhound.log' -> 'C:\\Users\\domainadmin\\AppData\\Local\\openhound\\logs\\openhound.log.2026-05-20'
```

Root cause: OpenHound opens the same log file twice during startup.
At import time, logging.py (line 401) runs logger_override.setup(). That setup attaches a rotating handler to the dlt logger at logging.py (line 297), then attaches another rotating handler to the root logger for the same openhound.log at logging.py (line 303). On Windows, TimedRotatingFileHandler cannot rename a file while another open handle still exists. Since the existing log was from 2026-05-20, the first startup log on 2026-05-21 triggers midnight rollover, closes only its own stream, then os.rename() fails because the other handler still has openhound.log open.

Recommended fix:
```
def _close_handlers(logger: logging.Logger) -> None:
    for handler in logger.handlers[:]:
        logger.removeHandler(handler)
        handler.close()
```

Use that instead of handlers.clear(), and make only one handler own openhound.log:
```
# setup()
_close_handlers(self.dlt_logger)
self.dlt_logger.setLevel(getattr(logging, self.level))
self.dlt_logger.propagate = True  # default DLT logs flow to root's single file handler

self.root_logger.setLevel(getattr(logging, self.level))
_close_handlers(self.root_logger)
self.handlers[self.runtime_mode](self.root_logger, self.log_file_path)
```

Then keep set_handler() for collector-specific DLT logs, but close old handlers first:
```
# set_handler()
_close_handlers(self.dlt_logger)
self.handlers[self.runtime_mode](self.dlt_logger, valid_path)
self.dlt_logger.propagate = False
```

For the scheduler/process-pool path, also avoid multiple processes rotating the same file. Best stdlib solution is QueueHandler/QueueListener so one parent listener owns the file handler; simpler fallback is per-process log filenames.