### PR TITLE
chore: bumping extension versions and added github enterprise config

### DIFF
--- a/example-configurations/bloodhound-community/.dlt-example/secrets_github.toml
+++ b/example-configurations/bloodhound-community/.dlt-example/secrets_github.toml
@@ -1,6 +1,13 @@
 # Example configuration for github secrets: https://bloodhound.specterops.io/openhound/collectors/github/collect-data#example-configuration
 [sources.source.github.credentials]
-app_id = "myappid"
+install_id = "myinstallid"
 client_id = "myclientid"
 key_path = "/app/.dlt/github.pem"
 org_name = "myorgname"
+
+#Example configuration for github enterprise
+[sources.source.github.credentials]
+app_id = "myappid"
+client_id = "myclientid"
+key_path = "/app/.dlt/github.pem"
+enterprise_name = "myenterprisename"

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_github.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_github.toml
@@ -6,7 +6,14 @@ url = "bhe_url"
 
 # Example configuration for github secrets: https://bloodhound.specterops.io/openhound/collectors/github/collect-data#example-configuration
 [sources.source.github.credentials]
-app_id = "myappid"
+install_id = "myinstallid"
 client_id = "myclientid"
 key_path = "/app/.dlt/github.pem"
 org_name = "myorgname"
+
+#Example configuration for github enterprise
+[sources.source.github.credentials]
+app_id = "myappid"
+client_id = "myclientid"
+key_path = "/app/.dlt/github.pem"
+enterprise_name = "myenterprisename"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,19 +23,19 @@ dependencies = [
 
 [project.optional-dependencies]
 all = [
-    "openhound-jamf==0.1.3",
-    "openhound-github==0.1.0",
-    "openhound-okta==0.1.2",
+    "openhound-jamf==0.2.0",
+    "openhound-github==0.3.0",
+    "openhound-okta==0.1.4",
 ]
 jamf = [
-    "openhound-jamf==0.1.3",
+    "openhound-jamf==0.2.0",
 ]
 github = [
-    "openhound-github==0.1.0"
+    "openhound-github==0.3.0"
 ]
 
 okta = [
-    "openhound-okta==0.1.2",
+    "openhound-okta==0.1.4",
 ]
 
 [project.scripts]


### PR DESCRIPTION
OpenHound extension version bumps for extension fixes
Okta: [BED-8389](https://specterops.atlassian.net/browse/BED-8389)
Jamf: [BED-8516](https://specterops.atlassian.net/browse/BED-8516)
Github: [BED-8357](https://specterops.atlassian.net/browse/BED-8357)

Version bumps:
openhound-jamf: 0.2.0
openhound-github: 0.3.0
openhound-okta: 0.1.4

Also added Github Enterprise config to .dlt-example

[BED-8389]: https://specterops.atlassian.net/browse/BED-8389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BED-8516]: https://specterops.atlassian.net/browse/BED-8516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BED-8357]: https://specterops.atlassian.net/browse/BED-8357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ