### PR TITLE
chore: adding guards to build-and-publish.yml

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -42,5 +42,28 @@ jobs:
       - name: Build package
         run: uv build
 
+      - name: Verify built version matches tag
+        run: |
+          REF="${{ inputs.tag || github.ref_name }}"
+          TAG_VERSION="${REF#v}"
+          echo "Tag version: ${TAG_VERSION}"
+          ls dist/
+          if ! ls "dist/openhound-${TAG_VERSION}.tar.gz" >/dev/null 2>&1 \
+             || ! ls "dist/openhound-${TAG_VERSION}-"*.whl >/dev/null 2>&1; then
+            echo "::error::Built artifacts in dist/ do not match tag version ${TAG_VERSION}."
+            echo "::error::This usually means hatch-vcs resolved a different tag (e.g. a lightweight tag pointing to the same commit). Re-tag on a distinct commit, preferably as an annotated tag."
+            exit 1
+          fi
+
+      - name: Verify version not already on PyPI
+        run: |
+          REF="${{ inputs.tag || github.ref_name }}"
+          TAG_VERSION="${REF#v}"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/openhound/${TAG_VERSION}/json")
+          if [ "${STATUS}" = "200" ]; then
+            echo "::error::openhound ${TAG_VERSION} already exists on PyPI; refusing to republish."
+            exit 1
+          fi
+
       - name: Publish package
-        run: uv publish
+        run: uv publish --check-url https://pypi.org/simple/

--- a/example-configurations/bloodhound-community/.dlt-example/secrets_jamf.toml
+++ b/example-configurations/bloodhound-community/.dlt-example/secrets_jamf.toml
@@ -1,5 +1,5 @@
 # Example configuration for jamf secrets: https://bloodhound.specterops.io/openhound/collectors/jamf/collect-data#example-configuration
-[sources.source.jamf]
+[sources.source.jamf.credentials]
 username = "myusername"
 host = "https://tenant.jamfcloud.com"
 password = "mypassword"

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_jamf.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_jamf.toml
@@ -5,7 +5,7 @@ token_key = "client_token_key"
 url = "bhe_url"
 
 # Example configuration for jamf secrets: https://bloodhound.specterops.io/openhound/collectors/jamf/collect-data#example-configuration
-[sources.source.jamf]
+[sources.source.jamf.credentials]
 username = "myusername"
 host = "https://mytenant.jamfcloud.com"
 password = "mypassword"


### PR DESCRIPTION
Added guards to build-and-publish.yml to make sure the github tag and pypi version matches and to verify the version is not in pypi. 
Fixing secrets_jame.toml example as well