### PR TITLE
NOJIRA: fix typo in enterprise docker-compose example

### DIFF
--- a/example-configurations/bloodhound-enterprise/docker-compose.yml
+++ b/example-configurations/bloodhound-enterprise/docker-compose.yml
@@ -1,5 +1,5 @@
 x-scheduler: &scheduler
-  image: specterops/openhound:${IMAGE_VERSION:latest-enterprise}
+  image: specterops/openhound:${IMAGE_VERSION:-latest-enterprise}
   restart: unless-stopped
   init: true
   volumes:


### PR DESCRIPTION
Fix default value in enterprise docker-compose example: `${IMAGE_VERSION:latest-enterprise}` → `${IMAGE_VERSION:-latest-enterprise}` so the image tag resolves correctly when IMAGE_VERSION is unset.