### PR TITLE
fix: set up log formatting to human readable text and set that as the default

### DIFF
--- a/example-configurations/bloodhound-community/.dlt-example/config.toml
+++ b/example-configurations/bloodhound-community/.dlt-example/config.toml
@@ -2,8 +2,10 @@
 [runtime]
 http_show_error_body = true
 log_cli_level = "WARNING"
-log_format = "JSON"
 log_rotate_when = "midnight"
+# Default: logs are set to human readable text
+# To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
+# log_format = "JSON"
 
 [extract]
 workers = 8

--- a/example-configurations/bloodhound-enterprise/.dlt-example/config.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/config.toml
@@ -2,8 +2,10 @@
 [runtime]
 http_show_error_body = true
 log_cli_level = "WARNING"
-log_format = "JSON"
 log_rotate_when = "midnight"
+# Default: logs are set to human readable text
+# To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
+# log_format = "JSON"
 
 [extract]
 workers = 8

--- a/src/openhound/core/logging.py
+++ b/src/openhound/core/logging.py
@@ -17,6 +17,8 @@ __version__ = version("openhound")
 
 VALID_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
+VALID_FORMATS = ["json", "text"]
+
 # This should be a complete list of default fields as part of a LogRecord
 # this is used to prevent custom fields overwriting the default LogRecord entries
 DEFAULT_LOG_FIELDS = [
@@ -155,6 +157,46 @@ class OpenHoundJSONFormatter(logging.Formatter):
         return json.dumps(log_data)
 
 
+class OpenHoundTextFormatter(logging.Formatter):
+    """Human-readable plain-text formatter for OpenHound file logs"""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format a log record as a single readable line with structured context.
+
+        Args:
+            record (logging.LogRecord): The original log record
+
+        Returns:
+            str: A human-readable plain-text representation of the log record
+        """
+        timestamp = self.formatTime(record, "%Y-%m-%d %H:%M:%S")
+        location = f"{record.name}:{record.funcName}:{record.lineno}"
+        log_line = (
+            f"{timestamp} [{record.levelname}] {location} - {record.getMessage()}"
+        )
+
+        # Append any custom/extra fields (e.g. resource, phase, extension) so the
+        # structured context is preserved without the noise of full JSON
+        extras = {
+            key: value
+            for key, value in record.__dict__.items()
+            if (
+                not key.startswith("_")
+                and key not in DEFAULT_LOG_FIELDS
+                and key != "taskName"
+                and value is not None
+            )
+        }
+        if extras:
+            extra_str = " ".join(f"{key}={value}" for key, value in extras.items())
+            log_line = f"{log_line} | {extra_str}"
+
+        if record.exc_info:
+            log_line = f"{log_line}\n{self.formatException(record.exc_info)}"
+
+        return log_line
+
+
 class OpenHoundRichFormatter(logging.Formatter):
     """Custom formatter for Rich when logging in CLI mode"""
 
@@ -182,6 +224,7 @@ class CustomLogger:
         interval: int = 1,
         cli_level: str = "ERROR",
         base_path: str | None = None,
+        log_format: str = "text",
     ):
         self.level = level
         self.name = name
@@ -192,6 +235,7 @@ class CustomLogger:
         self.backup_count = backup_count
         self.interval = interval
         self.cli_level = cli_level
+        self.log_format = log_format
 
         self.base_path = Path(base_path) if base_path else self.default_platform_path()
         self.log_file_path: Path | None = None
@@ -207,6 +251,14 @@ class CustomLogger:
         normalized_level = level.upper()
         if normalized_level in VALID_LEVELS:
             return normalized_level
+
+        return default
+
+    @staticmethod
+    def _validate_format(log_format: str, default: str = "text") -> str:
+        normalized_format = log_format.lower()
+        if normalized_format in VALID_FORMATS:
+            return normalized_format
 
         return default
 
@@ -275,11 +327,17 @@ class CustomLogger:
         dlt_interval = dlt.config.get("runtime.log_interval", int)
         dlt_cli_level = dlt.config.get("runtime.log_cli_level", str)
         dlt_log_path = dlt.config.get("runtime.log_path", str)
+        # dlt only treats the exact value "JSON" specially. We read it to select json logs and
+        # fall back to text for anything else (including dlt's default format string).
+        dlt_log_format = dlt.config.get("runtime.log_format", str)
 
         # Check if the DLT config values are valid and if so override the defaults
         self.level = self._validate_level(dlt_level or self.level, default="INFO")
         self.cli_level = self._validate_level(
             dlt_cli_level or self.cli_level, default="ERROR"
+        )
+        self.log_format = self._validate_format(
+            dlt_log_format or self.log_format, default="text"
         )
 
         # Override the base path if log_path is set in DLT config, otherwise use the default platform path
@@ -303,17 +361,29 @@ class CustomLogger:
         self.root_logger.handlers.clear()
         self.handlers[self.runtime_mode](self.root_logger, self.log_file_path)
 
+    def _file_formatter(self) -> logging.Formatter:
+        """Return the formatter for file/stdout handlers based on the configured log format.
+
+        Returns:
+            logging.Formatter: A JSON formatter when log_format is 'json', otherwise a
+            human-readable plain-text formatter.
+        """
+        if self.log_format == "json":
+            return OpenHoundJSONFormatter()
+        return OpenHoundTextFormatter()
+
     def container_handlers(self, logger: logging.Logger, file_path: Path) -> None:
         """Set the logging handler/format when running in a container"""
 
-        json_formatter = OpenHoundJSONFormatter()
+        formatter = self._file_formatter()
 
-        # Log to stdout in JSON for better compatibility with container-based logging systems
+        # Log to stdout for better compatibility with container-based logging systems.
+        # Output is human-readable text by default; set runtime.log_format = "JSON" for structured JSON.
         stdout_handler = logging.StreamHandler(sys.stdout)
-        stdout_handler.setFormatter(json_formatter)
+        stdout_handler.setFormatter(formatter)
         logger.addHandler(stdout_handler)
 
-        # But also log the same json format to a file for persistence and debugging when needed
+        # But also log the same format to a file for persistence and debugging when needed
         rotating_file_handler = RotatingFileHandler(
             file_path,
             when=self.rotate_when,
@@ -321,7 +391,7 @@ class CustomLogger:
             backupCount=self.backup_count,
             max_bytes=self.max_bytes,
         )
-        rotating_file_handler.setFormatter(json_formatter)
+        rotating_file_handler.setFormatter(formatter)
         # This regular expression overrides the default extMatch to recognize both
         # default time based rotation filenames and size based rotation filenames (which gets a seconds added as well)
         rotating_file_handler.extMatch = re.compile(
@@ -347,8 +417,8 @@ class CustomLogger:
         console_handler.setFormatter(rich_formatter)
         logger.addHandler(console_handler)
 
-        # But also save the logs to a file in JSON format :)
-        json_formatter = OpenHoundJSONFormatter()
+        # But also save the logs to a file using the configured format (text by default)
+        file_formatter = self._file_formatter()
         rotating_file_handler = RotatingFileHandler(
             file_path,
             when=self.rotate_when,
@@ -356,7 +426,7 @@ class CustomLogger:
             backupCount=self.backup_count,
             max_bytes=self.max_bytes,
         )
-        rotating_file_handler.setFormatter(json_formatter)
+        rotating_file_handler.setFormatter(file_formatter)
         # This regular expression overrides the default extMatch to recognize both
         # default time based rotation filenames and size based rotation filenames (which gets a seconds added as well)
         rotating_file_handler.extMatch = re.compile(
@@ -367,7 +437,7 @@ class CustomLogger:
 
     def service_handlers(self, logger: logging.Logger, file_path: Path) -> None:
         """Set the logging handler/format when running the OpenHound service"""
-        json_formatter = OpenHoundJSONFormatter()
+        file_formatter = self._file_formatter()
         rotating_file_handler = RotatingFileHandler(
             file_path,
             when=self.rotate_when,
@@ -375,7 +445,7 @@ class CustomLogger:
             backupCount=self.backup_count,
             max_bytes=self.max_bytes,
         )
-        rotating_file_handler.setFormatter(json_formatter)
+        rotating_file_handler.setFormatter(file_formatter)
         # This regular expression overrides the default extMatch to recognize both
         # default time based rotation filenames and size based rotation filenames (which gets a seconds added as well)
         rotating_file_handler.extMatch = re.compile(

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -1,7 +1,15 @@
 import json
 import logging
 
-from openhound.core.logging import RotatingFileHandler, logger_override
+import pytest
+
+from openhound.core.logging import (
+    CustomLogger,
+    OpenHoundJSONFormatter,
+    OpenHoundTextFormatter,
+    RotatingFileHandler,
+    logger_override,
+)
 
 
 def test_root_handler_setup():
@@ -59,8 +67,10 @@ def test_dlt_extension_handlers():
     )
 
 
-def test_log_routing_content(tmp_path, caplog):
+def test_log_routing_content(tmp_path, caplog, monkeypatch):
     """Test that logs are correctly routed and that the files are created for the expected paths"""
+    # Pin JSON (dlt's only crash-safe override value) so the JSON-parsing assertions are self-contained.
+    monkeypatch.setenv("RUNTIME__LOG_FORMAT", "JSON")
     logger_override.base_path = tmp_path
     logger_override.setup()
     logger_override.set_handler("test_extension")
@@ -94,3 +104,55 @@ def test_log_routing_content(tmp_path, caplog):
     assert ext_logs_json[0]["message"] == "Extension DLT log", (
         "The extension log message should be present in 'ext_test_extension.log'"
     )
+
+
+def test_validate_format_defaults_to_text():
+    """Test that the log format validation accepts text/json and falls back to text"""
+    assert CustomLogger._validate_format("JSON") == "json"
+    assert CustomLogger._validate_format("text") == "text"
+    assert CustomLogger._validate_format("invalid") == "text"
+
+
+def test_file_formatter_selection():
+    """Test that the configured log_format selects the matching file formatter"""
+    json_logger = CustomLogger("openhound.log", log_format="json")
+    assert isinstance(json_logger._file_formatter(), OpenHoundJSONFormatter), (
+        "log_format 'json' should produce a JSON formatter"
+    )
+
+    text_logger = CustomLogger("openhound.log", log_format="text")
+    assert isinstance(text_logger._file_formatter(), OpenHoundTextFormatter), (
+        "log_format 'text' should produce a plain-text formatter"
+    )
+
+
+def test_text_formatter_produces_plain_text():
+    """Test that the text formatter produces a readable, non-JSON line with extras"""
+    formatter = OpenHoundTextFormatter()
+    record = logging.LogRecord(
+        name="openhound.core.collect",
+        level=logging.ERROR,
+        pathname="collect.py",
+        lineno=61,
+        msg="Starting collector %s",
+        args=("github",),
+        exc_info=None,
+        func="run",
+    )
+    record.resource = "scim_users"
+    record.taskName = None
+
+    output = formatter.format(record)
+
+    assert "Starting collector github" in output, (
+        "The formatted message should be rendered with its args"
+    )
+    assert "[ERROR" in output, "The log level should be present in the output"
+    assert "openhound.core.collect:run:61" in output, (
+        "The logger/function/line location should be present in the output"
+    )
+    assert "resource=scim_users" in output, "Extra fields should be preserved"
+    assert "taskName" not in output, "Null extras like taskName should be dropped"
+
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(output)


### PR DESCRIPTION
## Description
OpenHound previously wrote all file/stdout logs as JSON, which is hard to read when tailing logs or debugging locally. So this introduces human-readable plain-text log format and makes it the default, while keeping structured JSON available as an opt-in.

Changes:

- New `OpenHoundTextFormatter` — renders each record as a single readable line: 
`2026-06-25 12:00:00 [INFO] logger:function:line - message | key=value`
- Extra/structured fields (e.g. resource, phase, extension) are appended as key=value pairs so context is preserved without full JSON. Null extras (like taskName) are dropped, and exceptions are appended on a following line.
- Format selection — added log_format (default "text"), a _validate_format() helper, and a _file_formatter() method that returns the JSON or text formatter based on config. All three handler modes (container, CLI, service) now use _file_formatter() instead of hardcoding JSON.
- Config toggle via dlt's reserved key — the format is read from runtime.log_format. dlt treats only the exact string "JSON" specially (and skips format-string validation for it), so we piggyback on that: "JSON" selects JSON logs; anything else (including dlt's default format string when unset) falls back to text. This avoids introducing a separate namespace and avoids the ValueError: invalid format crash that other values trigger.
- Example configs — removed the hardcoded log_format = "JSON" from both BloodHound Community and Enterprise example configs; documented text as the default with a commented, uppercase # log_format = "JSON" opt-in.

Tests:

- test_validate_format_defaults_to_text — validates "JSON"/"text" and the text fallback for invalid values.
- test_file_formatter_selection — confirms log_format selects the matching formatter.
- test_text_formatter_produces_plain_text — asserts the text output renders the message/args, level, location, and extras, and is not valid JSON.
- test_log_routing_content — pins RUNTIME__LOG_FORMAT=JSON so its JSON-parsing assertions stay self-contained regardless of the new default.

## Motivation and Context
Resolves: [BED-8744](https://specterops.atlassian.net/browse/BED-8744)

## Screenshots
Default:

> 2026-06-25 11:48:13 [INFO] openhound.core.manager:validate_metadata:119 - Extension 'faker' has valid metadata | extension=faker phase=metadata_validation
2026-06-25 11:48:13 [INFO] openhound.core.manager:from_entrypoint:156 - Loaded extension 'faker' from entry point 'openhound.sources' | extension=faker phase=extension_loading
2026-06-25 11:48:13 [INFO] openhound.core.manager:validate_metadata:119 - Extension 'github' has valid metadata | extension=github phase=metadata_validation
2026-06-25 11:48:13 [INFO] openhound.core.manager:from_entrypoint:156 - Loaded extension 'github' from entry point 'openhound.sources' | extension=github phase=extension_loading
2026-06-25 11:48:13 [INFO] openhound.core.manager:validate_metadata:119 - Extension 'jamf' has valid metadata | extension=jamf phase=metadata_validation
2026-06-25 11:48:13 [INFO] openhound.core.manager:from_entrypoint:156 - Loaded extension 'jamf' from entry point 'openhound.sources' | extension=jamf phase=extension_loading
2026-06-25 11:48:13 [INFO] openhound.core.collect:run:61 - Starting collector 'jamf'
2026-06-25 11:48:14 [ERROR] openhound.core.resources:sync_wrapper:68 - Error in resource 'users' during iteration: Expecting value: line 1 column 1 (char 0) | resource=users phase=resource_iteration

With `log_format = "JSON"` set in `config.toml`:

> {"timestamp": "2026-06-25 11:46:12", "level": "INFO", "logger": "openhound.core.manager", "module": "manager", "function": "validate_metadata", "line": 119, "message": "Extension 'faker' has valid metadata", "openhound_version": "0.2.9.dev1", "taskName": null, "extension": "faker", "phase": "metadata_validation"}
{"timestamp": "2026-06-25 11:46:12", "level": "INFO", "logger": "openhound.core.manager", "module": "manager", "function": "from_entrypoint", "line": 156, "message": "Loaded extension 'faker' from entry point 'openhound.sources'", "openhound_version": "0.2.9.dev1", "taskName": null, "extension": "faker", "phase": "extension_loading"}
{"timestamp": "2026-06-25 11:46:12", "level": "INFO", "logger": "openhound.core.manager", "module": "manager", "function": "validate_metadata", "line": 119, "message": "Extension 'github' has valid metadata", "openhound_version": "0.2.9.dev1", "taskName": null, "extension": "github", "phase": "metadata_validation"}


[BED-8744]: https://specterops.atlassian.net/browse/BED-8744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ