### PR TITLE
BED-8747: Check-in to BHE during collection

### DIFF
--- a/deployments/helm/openhound/templates/deployment.yaml
+++ b/deployments/helm/openhound/templates/deployment.yaml
@@ -59,10 +59,6 @@ spec:
             - name: DESTINATION__BLOODHOUNDENTERPRISE__URL
               value: {{ .Values.destination.bloodhoundEnterprise.url | quote }}
             {{- end }}
-            {{- if .Values.destination.bloodhoundEnterprise.interval }}
-            - name: DESTINATION__BLOODHOUNDENTERPRISE__INTERVAL
-              value: {{ .Values.destination.bloodhoundEnterprise.interval | quote }}
-            {{- end }}
             {{- range $name, $value := .Values.env }}
             - name: {{ $name }}
               value: {{ $value | quote }}

--- a/deployments/helm/openhound/values.yaml
+++ b/deployments/helm/openhound/values.yaml
@@ -46,7 +46,6 @@ collector:
 destination:
   bloodhoundEnterprise:
     url: ""
-    interval: ""
 
 resources: { }
 

--- a/deployments/helm/values.example.yaml
+++ b/deployments/helm/values.example.yaml
@@ -25,4 +25,3 @@ collector:
 destination:
   bloodhoundEnterprise:
     url: https://test.bloodhoundenterprise.io
-    interval: "300"

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_github.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_github.toml
@@ -1,5 +1,4 @@
 [destination.bloodhoundenterprise]
-interval = "300"
 token_id = "client_token_id"
 token_key = "client_token_key"
 url = "bhe_url"

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_jamf.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_jamf.toml
@@ -1,5 +1,4 @@
 [destination.bloodhoundenterprise]
-interval = "300"
 token_id = "client_token_id"
 token_key = "client_token_key"
 url = "bhe_url"

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_okta.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_okta.toml
@@ -1,5 +1,4 @@
 [destination.bloodhoundenterprise]
-interval = "300"
 token_id = "client_token_id"
 token_key = "client_token_key"
 url = "bhe_url"

--- a/example-configurations/bloodhound-enterprise/docker-compose.yml
+++ b/example-configurations/bloodhound-enterprise/docker-compose.yml
@@ -1,5 +1,5 @@
 x-scheduler: &scheduler
-  image: specterops/openhound:${IMAGE_VERSION:latest-enterprise}
+  image: specterops/openhound:${IMAGE_VERSION:-latest-enterprise}
   restart: unless-stopped
   init: true
   volumes:

--- a/src/openhound/scheduler/service.py
+++ b/src/openhound/scheduler/service.py
@@ -247,15 +247,10 @@ class Service:
         logger.info(
             f"Service started, monitoring {self.bhe_uri} every {self.interval} seconds."
         )
-        tick = 1  # seconds per loop iteration
-        last_poll = time.monotonic() - self.interval  # trigger _poll() immediately on first tick
         try:
             while not self.exit:
-                now = time.monotonic()
-                if now - last_poll >= self.interval:
-                    self._poll()
-                    self._checkin()   # no-op when idle
-                    last_poll = now
-                time.sleep(tick)
+                self._poll()
+                self._checkin()
+                time.sleep(self.interval)
         finally:
             self._shutdown()

--- a/src/openhound/scheduler/service.py
+++ b/src/openhound/scheduler/service.py
@@ -1,6 +1,5 @@
 import logging
 import signal
-import threading
 import time
 from concurrent.futures import Future, ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
@@ -70,7 +69,6 @@ class Service:
         token_id: str,
         collector_name: str,
         interval: int = 5,
-        checkin_interval: int = 30,
     ):
         # BHE client settings
         self.bhe_uri = bhe_uri
@@ -80,9 +78,6 @@ class Service:
         )
         # Interval how often to check for a job
         self.interval = interval
-
-        # Interval how often to send a check-in while a job is running
-        self.checkin_interval = checkin_interval
 
         # Stores the ID of currently running BHE job
         self.job_running: int | None = None
@@ -94,10 +89,6 @@ class Service:
         # Exit condition, changed to True when the process needs to stop
         self.exit = False
 
-        # Check-in thread and stop event
-        self._checkin_stop = threading.Event()
-        self._checkin_thread: threading.Thread | None = None
-
     def _exit_handler(self, sig: int, frame):
         """Handle SIGINT and SIGTERM signals. Sets self.exit to True to stop the while loop"""
         self.exit = True
@@ -107,7 +98,7 @@ class Service:
         """Send a check-in request to BHE to keep the client's LastCheckIn fresh.
 
         Only sends a request when a job is currently running. Exceptions are caught and
-        logged as warnings — they do not crash the thread or affect the running job.
+        logged as warnings — they do not crash the loop or affect the running job.
         """
         if self.job_running is None:
             return
@@ -117,17 +108,9 @@ class Service:
         except Exception:
             logger.warning("Check-in request to BHE failed.", exc_info=True)
 
-    def _checkin_loop(self) -> None:
-        """Background loop that calls _checkin every checkin_interval seconds."""
-        while not self._checkin_stop.wait(self.checkin_interval):
-            self._checkin()
-
     def _shutdown(self) -> None:
         """Shut down the executor and wait for running tasks to finish. Executed when the service is shut down."""
         logger.info("Collection service stopping.")
-        self._checkin_stop.set()
-        if self._checkin_thread is not None:
-            self._checkin_thread.join(timeout=5)
         self.executor.shutdown(wait=True, cancel_futures=True)
         logger.info("Collection service stopped.")
 
@@ -264,14 +247,15 @@ class Service:
         logger.info(
             f"Service started, monitoring {self.bhe_uri} every {self.interval} seconds."
         )
-        self._checkin_stop.clear()
-        self._checkin_thread = threading.Thread(
-            target=self._checkin_loop, daemon=True, name="bhe-checkin"
-        )
-        self._checkin_thread.start()
+        tick = 1  # seconds per loop iteration
+        last_poll = time.monotonic() - self.interval  # trigger _poll() immediately on first tick
         try:
             while not self.exit:
-                self._poll()
-                time.sleep(self.interval)
+                now = time.monotonic()
+                if now - last_poll >= self.interval:
+                    self._poll()
+                    self._checkin()   # no-op when idle
+                    last_poll = now
+                time.sleep(tick)
         finally:
             self._shutdown()

--- a/src/openhound/scheduler/service.py
+++ b/src/openhound/scheduler/service.py
@@ -1,5 +1,6 @@
 import logging
 import signal
+import threading
 import time
 from concurrent.futures import Future, ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
@@ -69,6 +70,7 @@ class Service:
         token_id: str,
         collector_name: str,
         interval: int = 5,
+        checkin_interval: int = 30,
     ):
         # BHE client settings
         self.bhe_uri = bhe_uri
@@ -78,6 +80,9 @@ class Service:
         )
         # Interval how often to check for a job
         self.interval = interval
+
+        # Interval how often to send a check-in while a job is running
+        self.checkin_interval = checkin_interval
 
         # Stores the ID of currently running BHE job
         self.job_running: int | None = None
@@ -89,14 +94,40 @@ class Service:
         # Exit condition, changed to True when the process needs to stop
         self.exit = False
 
+        # Check-in thread and stop event
+        self._checkin_stop = threading.Event()
+        self._checkin_thread: threading.Thread | None = None
+
     def _exit_handler(self, sig: int, frame):
         """Handle SIGINT and SIGTERM signals. Sets self.exit to True to stop the while loop"""
         self.exit = True
         logger.warning(f"Received signal {sig}, shutting down gracefully.")
 
+    def _checkin(self) -> None:
+        """Send a check-in request to BHE to keep the client's LastCheckIn fresh.
+
+        Only sends a request when a job is currently running. Exceptions are caught and
+        logged as warnings — they do not crash the thread or affect the running job.
+        """
+        if self.job_running is None:
+            return
+        try:
+            self.client.jobs_current
+            logger.debug(f"Check-in sent for job {self.job_running}.")
+        except Exception:
+            logger.warning("Check-in request to BHE failed.", exc_info=True)
+
+    def _checkin_loop(self) -> None:
+        """Background loop that calls _checkin every checkin_interval seconds."""
+        while not self._checkin_stop.wait(self.checkin_interval):
+            self._checkin()
+
     def _shutdown(self) -> None:
         """Shut down the executor and wait for running tasks to finish. Executed when the service is shut down."""
         logger.info("Collection service stopping.")
+        self._checkin_stop.set()
+        if self._checkin_thread is not None:
+            self._checkin_thread.join(timeout=5)
         self.executor.shutdown(wait=True, cancel_futures=True)
         logger.info("Collection service stopped.")
 
@@ -233,6 +264,11 @@ class Service:
         logger.info(
             f"Service started, monitoring {self.bhe_uri} every {self.interval} seconds."
         )
+        self._checkin_stop.clear()
+        self._checkin_thread = threading.Thread(
+            target=self._checkin_loop, daemon=True, name="bhe-checkin"
+        )
+        self._checkin_thread.start()
         try:
             while not self.exit:
                 self._poll()

--- a/src/openhound/scheduler/service.py
+++ b/src/openhound/scheduler/service.py
@@ -94,20 +94,6 @@ class Service:
         self.exit = True
         logger.warning(f"Received signal {sig}, shutting down gracefully.")
 
-    def _checkin(self) -> None:
-        """Send a check-in request to BHE to keep the client's LastCheckIn fresh.
-
-        Only sends a request when a job is currently running. Exceptions are caught and
-        logged as warnings — they do not crash the loop or affect the running job.
-        """
-        if self.job_running is None:
-            return
-        try:
-            self.client.jobs_current
-            logger.debug(f"Check-in sent for job {self.job_running}.")
-        except Exception:
-            logger.warning("Check-in request to BHE failed.", exc_info=True)
-
     def _shutdown(self) -> None:
         """Shut down the executor and wait for running tasks to finish. Executed when the service is shut down."""
         logger.info("Collection service stopping.")
@@ -237,6 +223,8 @@ class Service:
                 available_job = self.check_jobs()
                 if available_job:
                     self._start_job(available_job)
+            else:
+                self.client.jobs_current
         except Exception:
             logger.exception("Error checking for or starting jobs.")
 
@@ -250,7 +238,6 @@ class Service:
         try:
             while not self.exit:
                 self._poll()
-                self._checkin()
                 time.sleep(self.interval)
         finally:
             self._shutdown()

--- a/src/openhound/scheduler/service.py
+++ b/src/openhound/scheduler/service.py
@@ -13,6 +13,8 @@ from openhound.scheduler import dataflow
 
 logger = logging.getLogger(__name__)
 
+POLL_INTERVAL = 30  # seconds; fixed poll/check-in cadence, must remain below BHE's 600s client-checkin timeout
+
 
 class ExtensionNotFoundError(Exception):
     """Raised when the configured collector extension cannot be found."""
@@ -68,7 +70,6 @@ class Service:
         token_key: str,
         token_id: str,
         collector_name: str,
-        interval: int = 15,
     ):
         # BHE client settings
         self.bhe_uri = bhe_uri
@@ -77,7 +78,7 @@ class Service:
             bhe_uri=bhe_uri, token_key=token_key, token_id=token_id
         )
         # Interval how often to check for a job
-        self.interval = interval
+        self.interval = POLL_INTERVAL
 
         # Stores the ID of currently running BHE job
         self.job_running: int | None = None

--- a/src/openhound/scheduler/service.py
+++ b/src/openhound/scheduler/service.py
@@ -68,7 +68,7 @@ class Service:
         token_key: str,
         token_id: str,
         collector_name: str,
-        interval: int = 5,
+        interval: int = 15,
     ):
         # BHE client settings
         self.bhe_uri = bhe_uri

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -15,12 +15,6 @@ def start():
     # Load BHE config and secrets
     bhe_uri = dlt.config["destination.bloodhoundenterprise.url"]
     collector_name = dlt.config["destination.bloodhoundenterprise.collector_name"]
-    interval = dlt.config("destination.bloodhoundenterprise.interval")
-    try:
-        interval = int(interval)
-    except (TypeError, ValueError):
-        logger.warning(f"Invalid interval: {interval}, defaulting to 15")
-        interval = 15
 
     # Load BHE secrets
     token_key = dlt.secrets["destination.bloodhoundenterprise.token_key"]
@@ -33,7 +27,6 @@ def start():
         token_key=token_key,
         token_id=token_id,
         collector_name=collector_name,
-        interval=interval,
     )
     svc.start()
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -15,7 +15,12 @@ def start():
     # Load BHE config and secrets
     bhe_uri = dlt.config["destination.bloodhoundenterprise.url"]
     collector_name = dlt.config["destination.bloodhoundenterprise.collector_name"]
-    interval = dlt.config.get("destination.bloodhoundenterprise.interval", int)
+    interval = dlt.config("destination.bloodhoundenterprise.interval")
+    try:
+        interval = int(interval)
+    except (TypeError, ValueError):
+        logger.warning(f"Invalid interval: {interval}, defaulting to 15")
+        interval = 15
 
     # Load BHE secrets
     token_key = dlt.secrets["destination.bloodhoundenterprise.token_key"]

--- a/tests/test_bhe_job_scheduling.py
+++ b/tests/test_bhe_job_scheduling.py
@@ -114,7 +114,6 @@ def mock_service(mock_bloodhound_api, monkeypatch):
         bhe_uri="http://localhost:8000",
         token_key="test-key",
         token_id="test-id",
-        interval=1,
         collector_name="openhound-faker",
     )
 
@@ -248,8 +247,11 @@ def test_start_job_recovers_when_submit_raises_broken_pool(
 
 
 def test_checkin_calls_jobs_current_when_job_running(mock_service, monkeypatch):
-    """_checkin() should call jobs_current when a job is running."""
+    """_poll() should call jobs_current via the else-branch check-in when a job is running."""
+    # Simulate a job in progress with no completed future — skips the completion handler,
+    # reaches the else-branch, and triggers jobs_current as a check-in heartbeat.
     mock_service.job_running = 123
+    mock_service.future = None  # no completed future to handle
     called = []
 
     def fake_jobs_current(self):
@@ -259,14 +261,17 @@ def test_checkin_calls_jobs_current_when_job_running(mock_service, monkeypatch):
         mock_service.client.__class__, "jobs_current", property(fake_jobs_current)
     )
 
-    mock_service._checkin()
+    mock_service._poll()
 
     assert len(called) == 1
 
 
 def test_checkin_noop_when_no_job_running(mock_service, monkeypatch):
-    """_checkin() should not call jobs_current when no job is running."""
+    """_poll() should not call jobs_current via the else-branch check-in when no job is running."""
+    # When idle (job_running is None), _poll() takes the if-branch and calls check_jobs()
+    # instead of the else-branch check-in. jobs_current should never be touched.
     assert mock_service.job_running is None
+    mock_service.future = None
     called = []
 
     def fake_jobs_current(self):
@@ -275,15 +280,19 @@ def test_checkin_noop_when_no_job_running(mock_service, monkeypatch):
     monkeypatch.setattr(
         mock_service.client.__class__, "jobs_current", property(fake_jobs_current)
     )
+    # Stub check_jobs so _poll doesn't try to start a job; we only care the else-branch doesn't fire
+    monkeypatch.setattr(mock_service, "check_jobs", lambda: None)
 
-    mock_service._checkin()
+    mock_service._poll()
 
     assert len(called) == 0
 
 
 def test_checkin_swallows_exception(mock_service, monkeypatch):
-    """_checkin() should swallow exceptions from jobs_current without re-raising."""
+    """_poll() should swallow exceptions raised by jobs_current in the check-in else-branch."""
+    # A transient BHE error during check-in must not crash the service loop.
     mock_service.job_running = 123
+    mock_service.future = None  # no completed future to handle
 
     def raise_error(self):
         raise RuntimeError("BHE unreachable")
@@ -292,8 +301,8 @@ def test_checkin_swallows_exception(mock_service, monkeypatch):
         mock_service.client.__class__, "jobs_current", property(raise_error)
     )
 
-    # Should not raise
-    mock_service._checkin()
+    # Should not raise — _poll's except block absorbs the error
+    mock_service._poll()
 
 
 def test_scheduler_ingest_opengraph(mock_service, mock_bloodhound_api, monkeypatch):

--- a/tests/test_bhe_job_scheduling.py
+++ b/tests/test_bhe_job_scheduling.py
@@ -247,6 +247,55 @@ def test_start_job_recovers_when_submit_raises_broken_pool(
     }
 
 
+def test_checkin_calls_jobs_current_when_job_running(mock_service, monkeypatch):
+    """_checkin() should call jobs_current when a job is running."""
+    mock_service.job_running = 123
+    called = []
+
+    def fake_jobs_current(self):
+        called.append(True)
+
+    monkeypatch.setattr(
+        mock_service.client.__class__, "jobs_current", property(fake_jobs_current)
+    )
+
+    mock_service._checkin()
+
+    assert len(called) == 1
+
+
+def test_checkin_noop_when_no_job_running(mock_service, monkeypatch):
+    """_checkin() should not call jobs_current when no job is running."""
+    assert mock_service.job_running is None
+    called = []
+
+    def fake_jobs_current(self):
+        called.append(True)
+
+    monkeypatch.setattr(
+        mock_service.client.__class__, "jobs_current", property(fake_jobs_current)
+    )
+
+    mock_service._checkin()
+
+    assert len(called) == 0
+
+
+def test_checkin_swallows_exception(mock_service, monkeypatch):
+    """_checkin() should swallow exceptions from jobs_current without re-raising."""
+    mock_service.job_running = 123
+
+    def raise_error(self):
+        raise RuntimeError("BHE unreachable")
+
+    monkeypatch.setattr(
+        mock_service.client.__class__, "jobs_current", property(raise_error)
+    )
+
+    # Should not raise
+    mock_service._checkin()
+
+
 def test_scheduler_ingest_opengraph(mock_service, mock_bloodhound_api, monkeypatch):
     """Run the DLT pipeline with the openhound-faker collector + check the amount of ingested nodes + edges"""
     monkeypatch.setenv(


### PR DESCRIPTION
OpenHound stops making any API calls to BHE while a collection job runs. BHE kills the job after the 10-minute client check-in timeout.

This PR adds a periodic check-in so BHE knows the collector is still alive throughout a collection.

Changes:

    Hard-coded POLL_INTERVAL = 30 in service.py.
    Removed interval parameter from Service.init.
    Updated _poll() to branch based on job status:
    Idle: Calls check_jobs() to look for new jobs
    Active: Accesses self.client.jobs_current to perform a check-in
    Configuration & Cleanup:
    Removed all interval parsing and loading logic from src/scheduler.py.
    Purged DESTINATION__BLOODHOUNDENTERPRISE__INTERVAL and related interval keys from:
    deployments/helm/openhound/templates/deployment.yaml
    deployments/helm/openhound/values.yaml
    deployments/helm/values.example.yaml
    All .dlt-example/secrets_*.toml files.
    Tests:
    Unit tests added
    Updated test fixtures to remove the interval argument.

/resolves BED-8747