### PR TITLE
fix: move non-sensitive data out of secrets.toml - BED-8838

### DIFF
--- a/deployments/helm/openhound/README.md
+++ b/deployments/helm/openhound/README.md
@@ -46,11 +46,11 @@ collector:
   name: jamf
   extraSecretMounts: { }
 
-# The BHE destination config. This is typically stored inside the same secrets.toml referenced by config.existingSecret, but non-sensitive values can be provided here for convenience.
+# The BHE destination url is non-sensitive config; set it here, via environment variable, or in config.toml.
+# Sensitive credentials (token_id and token_key) belong in secrets.toml referenced by config.existingSecret.
 destination:
   bloodhoundEnterprise:
     url: https://test.bloodhoundenterprise.io
-    interval: "300"
 
 ```
 

--- a/deployments/helm/values.example.yaml
+++ b/deployments/helm/values.example.yaml
@@ -21,7 +21,8 @@ collector:
   name: jamf
   extraSecretMounts: { }
 
-# The BHE destination config. This is typically stored inside the same secrets.toml referenced by config.existingSecret, but non-sensitive values can be provided here for convenience.
+# The BHE destination url is non-sensitive config; set it here, via environment variable, or in config.toml.
+# Sensitive credentials (token_id and token_key) belong in secrets.toml referenced by config.existingSecret.
 destination:
   bloodhoundEnterprise:
     url: https://test.bloodhoundenterprise.io

--- a/example-configurations/bloodhound-enterprise/.dlt-example/config.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/config.toml
@@ -14,6 +14,10 @@ request_max_retry_delay = 900
 # To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
 # log_format = "JSON"
 
+# BHE destination URL (non-sensitive; tokens go in secrets.toml)
+[destination.bloodhoundenterprise]
+url = "bhe_url"
+
 [extract]
 workers = 8
 

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_github.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_github.toml
@@ -1,7 +1,6 @@
 [destination.bloodhoundenterprise]
 token_id = "client_token_id"
 token_key = "client_token_key"
-url = "bhe_url"
 
 # Example configuration for github secrets: https://bloodhound.specterops.io/openhound/collectors/github/collect-data#example-configuration
 [sources.source.github.credentials]

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_jamf.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_jamf.toml
@@ -1,7 +1,6 @@
 [destination.bloodhoundenterprise]
 token_id = "client_token_id"
 token_key = "client_token_key"
-url = "bhe_url"
 
 # Example configuration for jamf secrets: https://bloodhound.specterops.io/openhound/collectors/jamf/collect-data#example-configuration
 [sources.source.jamf.credentials]

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_okta.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_okta.toml
@@ -1,7 +1,6 @@
 [destination.bloodhoundenterprise]
 token_id = "client_token_id"
 token_key = "client_token_key"
-url = "bhe_url"
 
 # Example configuration for okta secrets: https://bloodhound.specterops.io/openhound/collectors/okta/collect-data#example-configuration
 [sources.source.okta.credentials]

--- a/example-configurations/bloodhound-enterprise/docker-compose.yml
+++ b/example-configurations/bloodhound-enterprise/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
 secrets:
   # Copy the .dlt-example folder to ${HOME}/.dlt as a starting point for each secrets file.
-  # Each secrets file must also contain [destination.bloodhoundenterprise] with url, token_id, and token_key.
+  # Each secrets file must contain [destination.bloodhoundenterprise] with token_id and token_key.
 
   # Jamf: username + password auth
   secrets_jamf:

--- a/src/openhound/destinations/bloodhound_enterprise/destination.py
+++ b/src/openhound/destinations/bloodhound_enterprise/destination.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def ingest(
     items: TDataItems,
     table: TTableSchema,
-    url: str = dlt.secrets.value,
+    url: str = dlt.config.value,
     token_id: str = dlt.secrets.value,
     token_key: str = dlt.secrets.value,
     source_kind: str = dlt.config.value,


### PR DESCRIPTION
Move non-sensitive values out of secrets.toml and into config.toml. 

/resolves BED-8838

> [!WARNING]
>  This will likely cause clients to need to fix their configuration and restart their services.
