### PR TITLE
fix: ensure DLT telemetry is disabled by default - BED-8855

### DIFF
--- a/src/openhound/core/logging.py
+++ b/src/openhound/core/logging.py
@@ -1,3 +1,7 @@
+import os
+
+os.environ.setdefault("RUNTIME__DLTHUB_TELEMETRY", "false")
+
 import json
 import logging
 import os

--- a/src/openhound/main.py
+++ b/src/openhound/main.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import dlt
-
 import openhound.core.logging  # noqa: F401
 from openhound.cli.collect import collect
 from openhound.cli.convert import convert
@@ -13,7 +11,6 @@ from openhound.cli.saved_search import saved_searches
 
 BASE_SOUCE_PATH = Path(__file__).parent / "sources"
 
-dlt.config["runtime.dlthub_telemetry"] = False
 app = TyperOverride(sources_path=BASE_SOUCE_PATH, pretty_exceptions_enable=True)
 
 app.add_typer(collect, name="collect")


### PR DESCRIPTION
fix: ensure DLT telemetry is disabled by default - [BED-8855](https://specterops.atlassian.net/browse/BED-8855)
Applies the dlt anonymous-telemetry opt-out via environment variable before any dlt runtime initialization occurs, so the tracker is never armed.

[BED-8838]: https://specterops.atlassian.net/browse/BED-8838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Verified:
- running without defining telemetry value uses deafult `false` - output INFO log:
- `DEBUG    time=2026-07-01 13:55:50, msg=Skipping request to external service: telemetry endpoint not set. (openhound_version=0.2.10.dev6)                                                                                                                                                         anon_tracker.py:206`

Running openhound with `RUNTIME__DLTHUB_TELEMETRY=true` does call the telemetry endpoint: 
- `DEBUG    time=2026-07-01 13:58:00, msg=https://telemetry.scalevector.ai:443 "POST / HTTP/1.1" 204 0 (openhound_version=0.2.10.dev6) connectionpool.py:544`
- `DEBUG    time=2026-07-01 13:58:00, msg=Tracker request returned a 204 response in 27.9986ms.s (openhound_version=0.2.10.dev6)`

[BED-8855]: https://specterops.atlassian.net/browse/BED-8855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ