### PR TITLE
fix: move non-sensitive data out of secrets.toml - BED-8838

### DIFF
--- a/deployments/helm/openhound/README.md
+++ b/deployments/helm/openhound/README.md
@@ -46,11 +46,11 @@ collector:
   name: jamf
   extraSecretMounts: { }
 
-# The BHE destination config. This is typically stored inside the same secrets.toml referenced by config.existingSecret, but non-sensitive values can be provided here for convenience.
+# The BHE destination url is non-sensitive config; set it here, via environment variable, or in config.toml.
+# Sensitive credentials (token_id and token_key) belong in secrets.toml referenced by config.existingSecret.
 destination:
   bloodhoundEnterprise:
     url: https://test.bloodhoundenterprise.io
-    interval: "300"
 
 ```
 

--- a/deployments/helm/values.example.yaml
+++ b/deployments/helm/values.example.yaml
@@ -21,7 +21,8 @@ collector:
   name: jamf
   extraSecretMounts: { }
 
-# The BHE destination config. This is typically stored inside the same secrets.toml referenced by config.existingSecret, but non-sensitive values can be provided here for convenience.
+# The BHE destination url is non-sensitive config; set it here, via environment variable, or in config.toml.
+# Sensitive credentials (token_id and token_key) belong in secrets.toml referenced by config.existingSecret.
 destination:
   bloodhoundEnterprise:
     url: https://test.bloodhoundenterprise.io

--- a/example-configurations/bloodhound-enterprise/.dlt-example/config.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/config.toml
@@ -14,6 +14,10 @@ request_max_retry_delay = 900
 # To switch to structured JSON instead, uncomment the line below (must be uppercase "JSON")
 # log_format = "JSON"
 
+# BHE destination URL (non-sensitive; tokens go in secrets.toml)
+[destination.bloodhoundenterprise]
+url = "bhe_url"
+
 [extract]
 workers = 8
 

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_github.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_github.toml
@@ -1,7 +1,6 @@
 [destination.bloodhoundenterprise]
 token_id = "client_token_id"
 token_key = "client_token_key"
-url = "bhe_url"
 
 # Example configuration for github secrets: https://bloodhound.specterops.io/openhound/collectors/github/collect-data#example-configuration
 [sources.source.github.credentials]

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_jamf.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_jamf.toml
@@ -1,7 +1,6 @@
 [destination.bloodhoundenterprise]
 token_id = "client_token_id"
 token_key = "client_token_key"
-url = "bhe_url"
 
 # Example configuration for jamf secrets: https://bloodhound.specterops.io/openhound/collectors/jamf/collect-data#example-configuration
 [sources.source.jamf.credentials]

--- a/example-configurations/bloodhound-enterprise/.dlt-example/secrets_okta.toml
+++ b/example-configurations/bloodhound-enterprise/.dlt-example/secrets_okta.toml
@@ -1,7 +1,6 @@
 [destination.bloodhoundenterprise]
 token_id = "client_token_id"
 token_key = "client_token_key"
-url = "bhe_url"
 
 # Example configuration for okta secrets: https://bloodhound.specterops.io/openhound/collectors/okta/collect-data#example-configuration
 [sources.source.okta.credentials]

--- a/example-configurations/bloodhound-enterprise/docker-compose.yml
+++ b/example-configurations/bloodhound-enterprise/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
 secrets:
   # Copy the .dlt-example folder to ${HOME}/.dlt as a starting point for each secrets file.
-  # Each secrets file must also contain [destination.bloodhoundenterprise] with url, token_id, and token_key.
+  # Each secrets file must contain [destination.bloodhoundenterprise] with token_id and token_key.
 
   # Jamf: username + password auth
   secrets_jamf:

--- a/src/openhound/destinations/bloodhound_enterprise/destination.py
+++ b/src/openhound/destinations/bloodhound_enterprise/destination.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def ingest(
     items: TDataItems,
     table: TTableSchema,
-    url: str = dlt.secrets.value,
+    url: str = dlt.config.value,
     token_id: str = dlt.secrets.value,
     token_key: str = dlt.secrets.value,
     source_kind: str = dlt.config.value,


### PR DESCRIPTION
Splits the BHE destination url out of `secrets.toml` and into `config.toml`, so that `secrets.toml` contains only credentials (token id and key), while `config.toml` holds non-sensitive config. 

/resolves BED-8838

> [!NOTE]
>  This change is backward-compatible - existing collectors will still work if URL is left in `secrets_<collector-name>.toml` after the update. Read below to find relevant DLT documentation that confirms this behavior.

- Updated example enterprise configs (extension-specific and general secrets.toml / config.toml) to reflect changes.
- Updated comments in `docker-compose.yml` (for enterprise) to reflect changes.
- Updated Helm README and comments related to the change
- Also removed a stale reference to `interval` which needed to be removed
- Ran locally and confirmed behavior. 


[DLT Config Documentation](https://dlthub.com/docs/general-usage/credentials/advanced#injection-rules) - our situation applies to rule #4.
-> Previously, we referenced the BHE URL via `dlt.secrets.value` - this meant that value had to be defined as an env variable or inside of `secrets.toml`. Because of how secret injection works, our update to now grab the URL from `dlt.config.value` allows DLT to search through the 2 previously mentioned places (env variables and `secrets.toml`) in ADDITION to `config.toml`. As a result, the URL can now be defined in `secrets.toml` or `config.toml`. **One caveat ** is that if URL is that, if URL defined in both files, the one in `secrets.toml` will take precedence after this change due to DLT's hierarchy. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The BloodHound Enterprise destination URL now comes from standard configuration by default, making setup more straightforward and keeping sensitive credentials separate.

* **Documentation**
  * Updated setup examples to show the destination URL as a non-sensitive setting.
  * Clarified that only token-based credentials should be stored in secrets files.
  * Refined sample configuration and compose guidance to match the new setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->