### PR TITLE
fix: Move URL from secrets.toml to config.toml for asset upload feature - BED-9063

### DIFF
--- a/src/openhound/core/convert.py
+++ b/src/openhound/core/convert.py
@@ -10,7 +10,6 @@ from dlt.extract.source import DltSource
 from dlt.pipeline.pipeline import Pipeline
 
 from openhound.core.asset import BaseAsset
-from openhound.core.clients.bloodhound import BloodHound
 from openhound.core.logging import logger_override
 from openhound.core.lookup import LookupManager
 from openhound.core.pipeline import BasePipeline
@@ -20,13 +19,6 @@ from openhound.destinations.opengraph.destination import opengraph_file
 from openhound.sources.opengraph.source import GraphResource, opengraph
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class Credentials:
-    url: str
-    token_key: str
-    token_id: str
 
 
 class Method(str, Enum):
@@ -52,16 +44,6 @@ class Converter(BasePipeline):
         self.lookup = lookup
         self.progress = progress
         self.method = method
-        self.client: BloodHound | None = None
-        self.upload_id: int | None = None
-
-    @property
-    def _credentials(self) -> Credentials:
-        return Credentials(
-            url=dlt.secrets["destination.bloodhound.url"],
-            token_id=dlt.secrets["destination.bloodhound.token_id"],
-            token_key=dlt.secrets["destination.bloodhound.token_key"],
-        )
 
     @property
     def pipeline(self) -> Pipeline:

--- a/src/openhound/destinations/bloodhound/destination.py
+++ b/src/openhound/destinations/bloodhound/destination.py
@@ -1,4 +1,4 @@
-src/openhound/core/convert.pyimport logging
+import logging
 from collections import defaultdict
 from enum import Enum
 

--- a/src/openhound/destinations/bloodhound/destination.py
+++ b/src/openhound/destinations/bloodhound/destination.py
@@ -1,4 +1,4 @@
-import logging
+src/openhound/core/convert.pyimport logging
 from collections import defaultdict
 from enum import Enum
 
@@ -29,7 +29,7 @@ class Permissions(str, Enum):
 def saved_searches(
     items: TDataItems,
     table: TTableSchema,
-    url: str = dlt.secrets.value,
+    url: str = dlt.config.value,
     token: str = dlt.secrets.value,
     strategy: Strategy = Strategy.skip,
     permissions: Permissions = Permissions.public,
@@ -68,7 +68,7 @@ def saved_searches(
 def privilege_zones(
     items: TDataItems,
     table: TTableSchema,
-    url: str = dlt.secrets.value,
+    url: str = dlt.config.value,
     token: str = dlt.secrets.value,
     strategy: Strategy = Strategy.skip,
 ):


### PR DESCRIPTION
## BED-9063: Split BloodHound asset upload config between config.toml and secrets.toml

### Context
[BED-8838](https://specterops.atlassian.net/browse/BED-8838) moved the BHE URL out of `secrets.toml` into `config.toml` for the scheduler/collection destination (`destination.bloodhoundenterprise`), but missed the CLI Asset Upload destination (`destination.bloodhound`), which still required `url` as a secret.

### Changes
- `destinations/bloodhound/destination.py`: `url` param on `saved_searches` and `privilege_zones` now resolves via `dlt.config.value` instead of `dlt.secrets.value`. `token` remains `dlt.secrets.value`.
- `core/convert.py`: Removed dead code left over from an abandoned first implementation — the `Credentials` dataclass, `Converter._credentials` property, and the unused `self.client` / `self.upload_id` attributes (and their now-unused `BloodHound` import). These referenced a client that was never actually instantiated; the real ingest path uses `BloodHoundEnterprise` via the `@dlt.destination` function pattern.

> [!IMPORTANT]
> Please open a related PR for an update to the offical BloodHound documentation! 

### Testing
- Full `pytest` suite run
- Backwards-compatibility check: manually verified that `dlt.config.value` still resolves `url` if a user's `secrets.toml` still has it there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BloodHound destination configuration so connection URLs are sourced consistently from application configuration.
* **Refactor**
  * Removed obsolete credential handling from the conversion workflow, simplifying how connection details are prepared.
  * Kept conversion behavior the same, including choosing between enterprise ingest and file output based on the selected method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[BED-8838]: https://specterops.atlassian.net/browse/BED-8838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ