### PR TITLE
BED-9520: Make source_kind optional and remove it from the OG metadata

### DIFF
--- a/src/openhound/core/app.py
+++ b/src/openhound/core/app.py
@@ -1,8 +1,3 @@
-import logging
-from enum import Enum
-from pathlib import Path
-from typing import Annotated, Callable, List
-
 import dlt
 import duckdb
 import typer
@@ -10,7 +5,11 @@ from dlt.common.libs import pydantic as dlt_pydantic
 from dlt.common.pipeline import LoadInfo
 from dlt.extract.resource import DltResource
 from dlt.extract.source import DltSource
+from enum import Enum
+from pathlib import Path
+from typing import Annotated, Callable, List
 
+import logging
 from openhound.cli.collect import collect
 from openhound.cli.convert import convert
 from openhound.cli.preproc import preprocess
@@ -52,7 +51,7 @@ class Contract(str, Enum):
 
 
 class OpenHound:
-    def __init__(self, name: str, source_kind: str, help: str = "OpenGraph collector"):
+    def __init__(self, name: str, source_kind: str | None = None, help: str = "OpenGraph collector"):
         dlt_pydantic.create_list_model = validate.create_list_model
         dlt_pydantic._classify_validation_errors = validate._classify_validation_errors
 
@@ -78,9 +77,9 @@ class OpenHound:
         self.edges: list[EdgeDef] = []
 
     def collect(
-        self,
-        help: str = "OpenGraph collect pipeline",
-        **kwargs,
+            self,
+            help: str = "OpenGraph collect pipeline",
+            **kwargs,
     ):
         """Register a Typer CLI command that collects resources and stores them (filtered) on disk.
 
@@ -92,29 +91,29 @@ class OpenHound:
 
         def decorator(func: Callable):
             def wrapper(
-                output_path: OutputPath,
-                resources: List[str] = typer.Argument(None),
-                progress: Progress = typer.Option(
-                    Progress.tqdm, help="Select progress tracker option"
-                ),
-                tables_contract: Annotated[
-                    Contract,
-                    typer.Option(
-                        help="DLT contract applied when data contains newly seen resources/tables previously not collected",
+                    output_path: OutputPath,
+                    resources: List[str] = typer.Argument(None),
+                    progress: Progress = typer.Option(
+                        Progress.tqdm, help="Select progress tracker option"
                     ),
-                ] = Contract.evolve,
-                columns_contract: Annotated[
-                    Contract,
-                    typer.Option(
-                        help="DLT contract applied when data contains values/keys not found in the Pydantic model",
-                    ),
-                ] = Contract.evolve,
-                data_type_contract: Annotated[
-                    Contract,
-                    typer.Option(
-                        help="DLT contract applied when fields do not match the data types defined in the Pydantic model",
-                    ),
-                ] = Contract.discard_row,
+                    tables_contract: Annotated[
+                        Contract,
+                        typer.Option(
+                            help="DLT contract applied when data contains newly seen resources/tables previously not collected",
+                        ),
+                    ] = Contract.evolve,
+                    columns_contract: Annotated[
+                        Contract,
+                        typer.Option(
+                            help="DLT contract applied when data contains values/keys not found in the Pydantic model",
+                        ),
+                    ] = Contract.evolve,
+                    data_type_contract: Annotated[
+                        Contract,
+                        typer.Option(
+                            help="DLT contract applied when fields do not match the data types defined in the Pydantic model",
+                        ),
+                    ] = Contract.discard_row,
             ) -> LoadInfo | None:
                 schema_contract = {
                     "tables": tables_contract,
@@ -142,10 +141,10 @@ class OpenHound:
         return decorator
 
     def convert(
-        self,
-        lookup: Callable | None = None,
-        help: str = "OpenGraph convert pipeline",
-        **typer_kwargs,
+            self,
+            lookup: Callable | None = None,
+            help: str = "OpenGraph convert pipeline",
+            **typer_kwargs,
     ):
         """Register a Typer CLI command that converts collected resources to OpenGraph nodes and edges.
 
@@ -158,11 +157,11 @@ class OpenHound:
 
         def decorator(func: Callable):
             def run_convert(
-                input_path: InputPath,
-                output_path: Path = Path("/tmp/openhound"),
-                lookup_file: Path = DEFAULT_LOOKUP_FILE,
-                progress: Progress = Progress.tqdm,
-                method: Method = Method.write,
+                    input_path: InputPath,
+                    output_path: Path = Path("/tmp/openhound"),
+                    lookup_file: Path = DEFAULT_LOOKUP_FILE,
+                    progress: Progress = Progress.tqdm,
+                    method: Method = Method.write,
             ) -> LoadInfo:
                 lookup_session = None
                 if lookup:
@@ -197,31 +196,31 @@ class OpenHound:
                 )
 
             def wrapper(
-                input_path: InputPath,
-                output_path: Annotated[
-                    Path,
-                    typer.Argument(
-                        exists=False,
-                        file_okay=False,
-                        dir_okay=True,
-                        resolve_path=True,
-                        help="Output path to write OpenGraph JSON files",
+                    input_path: InputPath,
+                    output_path: Annotated[
+                        Path,
+                        typer.Argument(
+                            exists=False,
+                            file_okay=False,
+                            dir_okay=True,
+                            resolve_path=True,
+                            help="Output path to write OpenGraph JSON files",
+                        ),
+                    ],
+                    # resources: List[str] = typer.Argument(None),
+                    progress: Progress = typer.Option(
+                        Progress.tqdm, help="Select progress tracker option"
                     ),
-                ],
-                # resources: List[str] = typer.Argument(None),
-                progress: Progress = typer.Option(
-                    Progress.tqdm, help="Select progress tracker option"
-                ),
-                lookup_file: Annotated[
-                    Path,
-                    typer.Option(
-                        file_okay=True,
-                        dir_okay=False,
-                        readable=True,
-                        resolve_path=True,
-                        help="DuckDB lookup file path",
-                    ),
-                ] = DEFAULT_LOOKUP_FILE,
+                    lookup_file: Annotated[
+                        Path,
+                        typer.Option(
+                            file_okay=True,
+                            dir_okay=False,
+                            readable=True,
+                            resolve_path=True,
+                            help="DuckDB lookup file path",
+                        ),
+                    ] = DEFAULT_LOOKUP_FILE,
             ) -> LoadInfo:
                 return run_convert(
                     input_path=input_path,
@@ -241,10 +240,10 @@ class OpenHound:
         return decorator
 
     def preproc(
-        self,
-        transformer: Callable[[any], None] | None = None,
-        help: str = "OpenGraph preprocessing pipeline",
-        **typer_kwargs,
+            self,
+            transformer: Callable[[any], None] | None = None,
+            help: str = "OpenGraph preprocessing pipeline",
+            **typer_kwargs,
     ):
         """Register a Typer CLI command that performs optional preprocessing and builds lookup data for a source.
 
@@ -258,19 +257,19 @@ class OpenHound:
             self.preprocessor = func
 
             def wrapper(
-                input_path: InputPath,
-                output_file: Annotated[
-                    Path,
-                    typer.Argument(
-                        file_okay=True,
-                        dir_okay=False,
-                        readable=True,
-                        resolve_path=True,
+                    input_path: InputPath,
+                    output_file: Annotated[
+                        Path,
+                        typer.Argument(
+                            file_okay=True,
+                            dir_okay=False,
+                            readable=True,
+                            resolve_path=True,
+                        ),
+                    ] = DEFAULT_LOOKUP_FILE,
+                    progress: Progress = typer.Option(
+                        Progress.tqdm, help="Select progress tracker option"
                     ),
-                ] = DEFAULT_LOOKUP_FILE,
-                progress: Progress = typer.Option(
-                    Progress.tqdm, help="Select progress tracker option"
-                ),
             ) -> LoadInfo:
                 preprocessor = PreProcessor(
                     name=self.name,
@@ -299,9 +298,9 @@ class OpenHound:
         return dlt.defer(safe_func)
 
     def transformer(
-        self,
-        *dlt_args,
-        **dlt_kwargs,
+            self,
+            *dlt_args,
+            **dlt_kwargs,
     ):
         """Decorator to register a DLT transformer with added exception handling."""
 
@@ -316,9 +315,9 @@ class OpenHound:
         return decorator
 
     def resource(
-        self,
-        *dlt_args,
-        **dlt_kwargs,
+            self,
+            *dlt_args,
+            **dlt_kwargs,
     ):
         """Decorator to register a DLT resource with added exception handling."""
 
@@ -333,9 +332,9 @@ class OpenHound:
         return decorator
 
     def source(
-        self,
-        *dlt_args,
-        **dlt_kwargs,
+            self,
+            *dlt_args,
+            **dlt_kwargs,
     ):
         """Decorator to register a DLT source with added exception handling.
 
@@ -353,10 +352,10 @@ class OpenHound:
         return decorator
 
     def asset(
-        self,
-        node: NodeDef | None = None,
-        edges: list[EdgeDef] | None = None,
-        description: str = "Resource model for OpenGraph",
+            self,
+            node: NodeDef | None = None,
+            edges: list[EdgeDef] | None = None,
+            description: str = "Resource model for OpenGraph",
     ):
         """Decorator to register a resource class and its graph definitions (nodes/edges). This is used to automatically
         generate documentation for each unique resource and implement rules/warnings when nodes/edges are returned

--- a/src/openhound/core/app.py
+++ b/src/openhound/core/app.py
@@ -1,3 +1,8 @@
+import logging
+from enum import Enum
+from pathlib import Path
+from typing import Annotated, Callable, List
+
 import dlt
 import duckdb
 import typer
@@ -5,11 +10,7 @@ from dlt.common.libs import pydantic as dlt_pydantic
 from dlt.common.pipeline import LoadInfo
 from dlt.extract.resource import DltResource
 from dlt.extract.source import DltSource
-from enum import Enum
-from pathlib import Path
-from typing import Annotated, Callable, List
 
-import logging
 from openhound.cli.collect import collect
 from openhound.cli.convert import convert
 from openhound.cli.preproc import preprocess
@@ -51,7 +52,12 @@ class Contract(str, Enum):
 
 
 class OpenHound:
-    def __init__(self, name: str, source_kind: str | None = None, help: str = "OpenGraph collector"):
+    def __init__(
+        self,
+        name: str,
+        source_kind: str | None = None,
+        help: str = "OpenGraph collector",
+    ):
         dlt_pydantic.create_list_model = validate.create_list_model
         dlt_pydantic._classify_validation_errors = validate._classify_validation_errors
 
@@ -77,9 +83,9 @@ class OpenHound:
         self.edges: list[EdgeDef] = []
 
     def collect(
-            self,
-            help: str = "OpenGraph collect pipeline",
-            **kwargs,
+        self,
+        help: str = "OpenGraph collect pipeline",
+        **kwargs,
     ):
         """Register a Typer CLI command that collects resources and stores them (filtered) on disk.
 
@@ -91,29 +97,29 @@ class OpenHound:
 
         def decorator(func: Callable):
             def wrapper(
-                    output_path: OutputPath,
-                    resources: List[str] = typer.Argument(None),
-                    progress: Progress = typer.Option(
-                        Progress.tqdm, help="Select progress tracker option"
+                output_path: OutputPath,
+                resources: List[str] = typer.Argument(None),
+                progress: Progress = typer.Option(
+                    Progress.tqdm, help="Select progress tracker option"
+                ),
+                tables_contract: Annotated[
+                    Contract,
+                    typer.Option(
+                        help="DLT contract applied when data contains newly seen resources/tables previously not collected",
                     ),
-                    tables_contract: Annotated[
-                        Contract,
-                        typer.Option(
-                            help="DLT contract applied when data contains newly seen resources/tables previously not collected",
-                        ),
-                    ] = Contract.evolve,
-                    columns_contract: Annotated[
-                        Contract,
-                        typer.Option(
-                            help="DLT contract applied when data contains values/keys not found in the Pydantic model",
-                        ),
-                    ] = Contract.evolve,
-                    data_type_contract: Annotated[
-                        Contract,
-                        typer.Option(
-                            help="DLT contract applied when fields do not match the data types defined in the Pydantic model",
-                        ),
-                    ] = Contract.discard_row,
+                ] = Contract.evolve,
+                columns_contract: Annotated[
+                    Contract,
+                    typer.Option(
+                        help="DLT contract applied when data contains values/keys not found in the Pydantic model",
+                    ),
+                ] = Contract.evolve,
+                data_type_contract: Annotated[
+                    Contract,
+                    typer.Option(
+                        help="DLT contract applied when fields do not match the data types defined in the Pydantic model",
+                    ),
+                ] = Contract.discard_row,
             ) -> LoadInfo | None:
                 schema_contract = {
                     "tables": tables_contract,
@@ -141,10 +147,10 @@ class OpenHound:
         return decorator
 
     def convert(
-            self,
-            lookup: Callable | None = None,
-            help: str = "OpenGraph convert pipeline",
-            **typer_kwargs,
+        self,
+        lookup: Callable | None = None,
+        help: str = "OpenGraph convert pipeline",
+        **typer_kwargs,
     ):
         """Register a Typer CLI command that converts collected resources to OpenGraph nodes and edges.
 
@@ -157,11 +163,11 @@ class OpenHound:
 
         def decorator(func: Callable):
             def run_convert(
-                    input_path: InputPath,
-                    output_path: Path = Path("/tmp/openhound"),
-                    lookup_file: Path = DEFAULT_LOOKUP_FILE,
-                    progress: Progress = Progress.tqdm,
-                    method: Method = Method.write,
+                input_path: InputPath,
+                output_path: Path = Path("/tmp/openhound"),
+                lookup_file: Path = DEFAULT_LOOKUP_FILE,
+                progress: Progress = Progress.tqdm,
+                method: Method = Method.write,
             ) -> LoadInfo:
                 lookup_session = None
                 if lookup:
@@ -196,31 +202,31 @@ class OpenHound:
                 )
 
             def wrapper(
-                    input_path: InputPath,
-                    output_path: Annotated[
-                        Path,
-                        typer.Argument(
-                            exists=False,
-                            file_okay=False,
-                            dir_okay=True,
-                            resolve_path=True,
-                            help="Output path to write OpenGraph JSON files",
-                        ),
-                    ],
-                    # resources: List[str] = typer.Argument(None),
-                    progress: Progress = typer.Option(
-                        Progress.tqdm, help="Select progress tracker option"
+                input_path: InputPath,
+                output_path: Annotated[
+                    Path,
+                    typer.Argument(
+                        exists=False,
+                        file_okay=False,
+                        dir_okay=True,
+                        resolve_path=True,
+                        help="Output path to write OpenGraph JSON files",
                     ),
-                    lookup_file: Annotated[
-                        Path,
-                        typer.Option(
-                            file_okay=True,
-                            dir_okay=False,
-                            readable=True,
-                            resolve_path=True,
-                            help="DuckDB lookup file path",
-                        ),
-                    ] = DEFAULT_LOOKUP_FILE,
+                ],
+                # resources: List[str] = typer.Argument(None),
+                progress: Progress = typer.Option(
+                    Progress.tqdm, help="Select progress tracker option"
+                ),
+                lookup_file: Annotated[
+                    Path,
+                    typer.Option(
+                        file_okay=True,
+                        dir_okay=False,
+                        readable=True,
+                        resolve_path=True,
+                        help="DuckDB lookup file path",
+                    ),
+                ] = DEFAULT_LOOKUP_FILE,
             ) -> LoadInfo:
                 return run_convert(
                     input_path=input_path,
@@ -240,10 +246,10 @@ class OpenHound:
         return decorator
 
     def preproc(
-            self,
-            transformer: Callable[[any], None] | None = None,
-            help: str = "OpenGraph preprocessing pipeline",
-            **typer_kwargs,
+        self,
+        transformer: Callable[[any], None] | None = None,
+        help: str = "OpenGraph preprocessing pipeline",
+        **typer_kwargs,
     ):
         """Register a Typer CLI command that performs optional preprocessing and builds lookup data for a source.
 
@@ -257,19 +263,19 @@ class OpenHound:
             self.preprocessor = func
 
             def wrapper(
-                    input_path: InputPath,
-                    output_file: Annotated[
-                        Path,
-                        typer.Argument(
-                            file_okay=True,
-                            dir_okay=False,
-                            readable=True,
-                            resolve_path=True,
-                        ),
-                    ] = DEFAULT_LOOKUP_FILE,
-                    progress: Progress = typer.Option(
-                        Progress.tqdm, help="Select progress tracker option"
+                input_path: InputPath,
+                output_file: Annotated[
+                    Path,
+                    typer.Argument(
+                        file_okay=True,
+                        dir_okay=False,
+                        readable=True,
+                        resolve_path=True,
                     ),
+                ] = DEFAULT_LOOKUP_FILE,
+                progress: Progress = typer.Option(
+                    Progress.tqdm, help="Select progress tracker option"
+                ),
             ) -> LoadInfo:
                 preprocessor = PreProcessor(
                     name=self.name,
@@ -298,9 +304,9 @@ class OpenHound:
         return dlt.defer(safe_func)
 
     def transformer(
-            self,
-            *dlt_args,
-            **dlt_kwargs,
+        self,
+        *dlt_args,
+        **dlt_kwargs,
     ):
         """Decorator to register a DLT transformer with added exception handling."""
 
@@ -315,9 +321,9 @@ class OpenHound:
         return decorator
 
     def resource(
-            self,
-            *dlt_args,
-            **dlt_kwargs,
+        self,
+        *dlt_args,
+        **dlt_kwargs,
     ):
         """Decorator to register a DLT resource with added exception handling."""
 
@@ -332,9 +338,9 @@ class OpenHound:
         return decorator
 
     def source(
-            self,
-            *dlt_args,
-            **dlt_kwargs,
+        self,
+        *dlt_args,
+        **dlt_kwargs,
     ):
         """Decorator to register a DLT source with added exception handling.
 
@@ -352,10 +358,10 @@ class OpenHound:
         return decorator
 
     def asset(
-            self,
-            node: NodeDef | None = None,
-            edges: list[EdgeDef] | None = None,
-            description: str = "Resource model for OpenGraph",
+        self,
+        node: NodeDef | None = None,
+        edges: list[EdgeDef] | None = None,
+        description: str = "Resource model for OpenGraph",
     ):
         """Decorator to register a resource class and its graph definitions (nodes/edges). This is used to automatically
         generate documentation for each unique resource and implement rules/warnings when nodes/edges are returned

--- a/src/openhound/core/app.pyi
+++ b/src/openhound/core/app.pyi
@@ -48,7 +48,7 @@ class Asset:
 
 class OpenHound:
     name: str
-    source_kind: str
+    source_kind: str | None = None
     help: str
     metadata: Extension | None
     collector: Callable | None
@@ -65,7 +65,10 @@ class OpenHound:
     edges: list[EdgeDef]
 
     def __init__(
-        self, name: str, source_kind: str, help: str = "OpenGraph collector"
+        self,
+        name: str,
+        source_kind: str | None = None,
+        help: str = "OpenGraph collector",
     ): ...
     def icons(self, color: str, help: str = "BloodHound icons sync"): ...
     def queries(self, help: str = "BloodHound icons sync"): ...

--- a/src/openhound/core/convert.py
+++ b/src/openhound/core/convert.py
@@ -33,7 +33,7 @@ class Converter(BasePipeline):
         input_path: Path,
         lookup: LookupManager,
         output_path: Path,
-        source_kind: str,
+        source_kind: str | None = None,
         progress: Progress = Progress.tqdm,
         method: Method = Method.write,
     ):
@@ -51,13 +51,11 @@ class Converter(BasePipeline):
             logger.debug(
                 "Initializing BloodHound Enterprise client for converter ingest method"
             )
-            dest = ingest(source_kind=self.source_kind)
+            dest = ingest()
 
         else:
             logger.debug("Using file output method for converter")
-            dest = opengraph_file(
-                output_path=str(self.output_path), source_kind=self.source_kind
-            )
+            dest = opengraph_file(output_path=str(self.output_path))
 
         pipeline = dlt.pipeline(
             pipeline_name=f"{self.name}_convert",
@@ -99,6 +97,7 @@ class Converter(BasePipeline):
                 lookup=self.lookup,
                 bucket_url=str(self.input_path),
                 extras=extra_context,
+                source_kind=self.source_kind,
             )
         )
 

--- a/src/openhound/destinations/bloodhound_enterprise/destination.py
+++ b/src/openhound/destinations/bloodhound_enterprise/destination.py
@@ -19,9 +19,7 @@ def ingest(
     url: str = dlt.config.value,
     token_id: str = dlt.secrets.value,
     token_key: str = dlt.secrets.value,
-    source_kind: str = dlt.config.value,
 ):
-
     client = BloodHoundEnterprise(token_key=token_key, token_id=token_id, bhe_uri=url)
 
     nodes = []
@@ -34,12 +32,5 @@ def ingest(
         if item["graph"]["entity_type"] == "edge":
             edges.extend(item["graph"]["content"])
 
-    client.ingest(
-        json.dumps(
-            {
-                "graph": {"nodes": nodes, "edges": edges},
-                "metadata": {"source_kind": source_kind},
-            }
-        )
-    )
+    client.ingest(json.dumps({"graph": {"nodes": nodes, "edges": edges}}))
     logger.info("Graph ingested to BloodHound Enterprise")

--- a/src/openhound/destinations/opengraph/destination.py
+++ b/src/openhound/destinations/opengraph/destination.py
@@ -28,12 +28,11 @@ def _load_items(file_path: str) -> Iterable[dict]:
 
 
 def _write_part(
-    items: list[dict],
-    table_name: str,
-    output_path: str,
-    source_kind: str,
-    part_number: int | None = None,
-    job_file_id: str | None = None,
+        items: list[dict],
+        table_name: str,
+        output_path: str,
+        part_number: int | None = None,
+        job_file_id: str | None = None,
 ) -> None:
     if part_number is None:
         DEST_PART[table_name] += 1
@@ -60,8 +59,7 @@ def _write_part(
         fh.write(
             json.dumps(
                 {
-                    "graph": {"nodes": nodes, "edges": edges},
-                    "metadata": {"source_kind": source_kind},
+                    "graph": {"nodes": nodes, "edges": edges}
                 }
             ),
         )
@@ -98,12 +96,10 @@ def _publish_parts(staging: Path, committed: Path, output_path: str) -> None:
 
 @dlt.destination(skip_dlt_columns_and_tables=True, batch_size=0)
 def opengraph_file(
-    items: str,
-    table: TTableSchema,
-    output_path: str = dlt.config.value,
-    source_kind: str = dlt.config.value,
+        items: str,
+        table: TTableSchema,
+        output_path: str = dlt.config.value,
 ):
-
     table_name = table.get("name") or "opengraph"
     staging, committed, file_id = _job_paths(items, output_path)
     if committed.exists():
@@ -124,7 +120,6 @@ def opengraph_file(
                 batch,
                 table_name,
                 str(staging),
-                source_kind,
                 part_number,
                 file_id,
             )
@@ -135,7 +130,6 @@ def opengraph_file(
             batch,
             table_name,
             str(staging),
-            source_kind,
             part_number,
             file_id,
         )

--- a/src/openhound/sources/opengraph/source.py
+++ b/src/openhound/sources/opengraph/source.py
@@ -7,7 +7,6 @@ from dlt.sources.filesystem import read_jsonl
 
 from openhound.core.asset import BaseAsset
 from openhound.core.lookup import LookupManager
-
 from .entries import GraphContent
 
 # DLT page boundary; partial pages flush per input file.
@@ -21,10 +20,11 @@ class GraphResource:
 
 
 def _generate_graph_content(
-    resources: Iterable[dict],
-    model: type[BaseAsset],
-    batch_size: int,
-    apply_context: Callable | None = None,
+        resources: Iterable[dict],
+        model: type[BaseAsset],
+        batch_size: int,
+        apply_context: Callable | None = None,
+        source_kind: str | None = None
 ):
     """Convert one DLT page into bounded OpenGraph batches."""
     edge_parts = []
@@ -41,6 +41,8 @@ def _generate_graph_content(
 
         as_node = parsed_resource.as_node
         if as_node:
+            if source_kind is not None and source_kind not in as_node.kinds:
+                as_node.kinds.append(source_kind)
             yield {
                 "graph": {
                     "content": serialize(as_node),
@@ -60,11 +62,12 @@ def _generate_graph_content(
 
 @dlt.source(name="opengraph", max_table_nesting=0)
 def opengraph(
-    graph_resources: list[GraphResource],
-    bucket_url: str,
-    lookup: LookupManager,
-    extras: dict | None = None,
-    batch_size: int = 150,
+        graph_resources: list[GraphResource],
+        bucket_url: str,
+        lookup: LookupManager,
+        extras: dict | None = None,
+        batch_size: int = 150,
+        source_kind: str | None = None
 ):
     if batch_size <= 0:
         raise ValueError("batch_size must be greater than zero")
@@ -76,17 +79,17 @@ def opengraph(
     for graph_resource in graph_resources:
         table_name = f"{graph_resource.model.__name__.lower()}_fs"
         reader = (
-            filesystemsource(
-                bucket_url=bucket_url,
-                file_glob=f"{graph_resource.table}/**/*.jsonl.gz",
-            )
-            | read_jsonl(chunksize=READ_JSONL_PAGE_SIZE)
+                filesystemsource(
+                    bucket_url=bucket_url,
+                    file_glob=f"{graph_resource.table}/**/*.jsonl.gz",
+                )
+                | read_jsonl(chunksize=READ_JSONL_PAGE_SIZE)
         )
 
         @dlt.transformer(parallelized=False, name=table_name, columns=GraphContent)
         def generate_graph(resources, model, apply_context: Callable | None = None):
             yield from _generate_graph_content(
-                resources, model, batch_size, apply_context
+                resources, model, batch_size, apply_context, source_kind=source_kind
             )
 
         yield reader | generate_graph(

--- a/src/openhound/sources/opengraph/source.py
+++ b/src/openhound/sources/opengraph/source.py
@@ -7,6 +7,7 @@ from dlt.sources.filesystem import read_jsonl
 
 from openhound.core.asset import BaseAsset
 from openhound.core.lookup import LookupManager
+
 from .entries import GraphContent
 
 # DLT page boundary; partial pages flush per input file.
@@ -20,11 +21,11 @@ class GraphResource:
 
 
 def _generate_graph_content(
-        resources: Iterable[dict],
-        model: type[BaseAsset],
-        batch_size: int,
-        apply_context: Callable | None = None,
-        source_kind: str | None = None
+    resources: Iterable[dict],
+    model: type[BaseAsset],
+    batch_size: int,
+    apply_context: Callable | None = None,
+    source_kind: str | None = None,
 ):
     """Convert one DLT page into bounded OpenGraph batches."""
     edge_parts = []
@@ -62,12 +63,12 @@ def _generate_graph_content(
 
 @dlt.source(name="opengraph", max_table_nesting=0)
 def opengraph(
-        graph_resources: list[GraphResource],
-        bucket_url: str,
-        lookup: LookupManager,
-        extras: dict | None = None,
-        batch_size: int = 150,
-        source_kind: str | None = None
+    graph_resources: list[GraphResource],
+    bucket_url: str,
+    lookup: LookupManager,
+    extras: dict | None = None,
+    batch_size: int = 150,
+    source_kind: str | None = None,
 ):
     if batch_size <= 0:
         raise ValueError("batch_size must be greater than zero")
@@ -78,13 +79,10 @@ def opengraph(
 
     for graph_resource in graph_resources:
         table_name = f"{graph_resource.model.__name__.lower()}_fs"
-        reader = (
-                filesystemsource(
-                    bucket_url=bucket_url,
-                    file_glob=f"{graph_resource.table}/**/*.jsonl.gz",
-                )
-                | read_jsonl(chunksize=READ_JSONL_PAGE_SIZE)
-        )
+        reader = filesystemsource(
+            bucket_url=bucket_url,
+            file_glob=f"{graph_resource.table}/**/*.jsonl.gz",
+        ) | read_jsonl(chunksize=READ_JSONL_PAGE_SIZE)
 
         @dlt.transformer(parallelized=False, name=table_name, columns=GraphContent)
         def generate_graph(resources, model, apply_context: Callable | None = None):

--- a/tests/test_opengraph_batching.py
+++ b/tests/test_opengraph_batching.py
@@ -64,6 +64,25 @@ def _edges(content):
     ]
 
 
+def test_source_kind_is_appended_to_emitted_node_kinds():
+    content = list(
+        _generate_graph_content(
+            [{"value": 1, "edge_count": 0, "has_node": True}],
+            _Asset,
+            1,
+            source_kind="Test_Source",
+        )
+    )
+
+    node = next(
+        item["graph"]["content"]
+        for item in content
+        if item["graph"]["entity_type"] == "node"
+    )
+
+    assert node["kinds"] == ["Test", "Test_Source"]
+
+
 def test_batches_edges_across_successive_rows_and_preserves_order():
     content = list(_generate_graph_content(_rows(1_001), _Asset, 150))
     wrappers = [item for item in content if item["graph"]["entity_type"] == "edge"]

--- a/tests/test_opengraph_destination.py
+++ b/tests/test_opengraph_destination.py
@@ -30,7 +30,7 @@ def test_load_file_streaming_reads_each_non_aligned_jsonl_item_once(tmp_path):
 
 def test_write_part_flattens_only_the_items_provided(tmp_path):
     DEST_PART.clear()
-    _write_part([_item(1), _item(2)], "test_fs", str(tmp_path), "test")
+    _write_part([_item(1), _item(2)], "test_fs", str(tmp_path))
 
     document = json.loads((tmp_path / "test_fs-1.json").read_text(encoding="utf-8"))
     assert document["graph"]["nodes"] == []
@@ -38,3 +38,4 @@ def test_write_part_flattens_only_the_items_provided(tmp_path):
         {"kind": "Test", "start": 1, "end": 2},
         {"kind": "Test", "start": 2, "end": 3},
     ]
+    assert "metadata" not in document

--- a/tests/test_opengraph_destination_retry.py
+++ b/tests/test_opengraph_destination_retry.py
@@ -54,9 +54,7 @@ def test_destination_retry_republishes_no_duplicate_parts(tmp_path, monkeypatch)
     pipeline = dlt.pipeline(
         pipeline_name="destination_retry_validation",
         dataset_name="destination_retry_validation",
-        destination=destination_module.opengraph_file(
-            output_path=str(output_dir), source_kind="test"
-        ),
+        destination=destination_module.opengraph_file(output_path=str(output_dir)),
     )
 
     # DLT retries the transient destination job in this call. The destination

--- a/tests/test_opengraph_dlt_integration.py
+++ b/tests/test_opengraph_dlt_integration.py
@@ -304,9 +304,7 @@ def test_opengraph_file_destination_retries_staged_load_without_duplicates(
     pipeline = dlt.pipeline(
         pipeline_name="opengraph_dlt_restart",
         dataset_name="opengraph_dlt_restart",
-        destination=file_destination.opengraph_file(
-            output_path=str(output_dir), source_kind="test"
-        ),
+        destination=file_destination.opengraph_file(output_path=str(output_dir)),
         pipelines_dir=str(tmp_path / "pipelines"),
     )
     source = opengraph(
@@ -376,7 +374,7 @@ def test_opengraph_file_destination_cold_restart_resumes_pending_job(tmp_path):
                     pipeline_name="opengraph_cold_restart",
                     dataset_name="opengraph_cold_restart",
                     destination=file_destination.opengraph_file(
-                        output_path=os.environ["GRAPH_OUTPUT"], source_kind="test"
+                        output_path=os.environ["GRAPH_OUTPUT"]
                     ),
                     pipelines_dir=os.environ["PIPELINES_DIR"],
                 )


### PR DESCRIPTION
## Summary

When a `source_kind` is present in the OpenGraph (metadata) output, edges directing to existing BloodHound nodes will overwrite the target node’s base kind. Ie. if the Github collector creates an edge to an Azure/AD node, the Azure/AD node will automatically inherit Github’s `source_kind`.

## Motivation
Resolves: BED-9520

## Changes
This change makes `source_kind` optional, and when defined, the `source_kind` is appended it to each node during conversion instead of adding it to the metadata. This still allows developers to add a base kind while fixing the overwriting issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source classification is now optional when creating and converting OpenGraph data.
  * When provided, source classifications are automatically added to emitted graph nodes.

* **Changes**
  * Simplified OpenGraph and BloodHound Enterprise output by removing redundant source metadata from generated files and ingestion payloads.
  * Existing workflows continue to operate without requiring a source classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->