### PR TITLE
fix: BED-9657 Add secrets.toml mount to example docker-compose

### DIFF
--- a/example-configurations/bloodhound-enterprise/docker-compose.yml
+++ b/example-configurations/bloodhound-enterprise/docker-compose.yml
@@ -7,6 +7,7 @@ x-scheduler: &scheduler
   init: true
   volumes:
     - ${HOME}/.dlt/config.toml:/app/.dlt/config.toml:ro
+    - ${HOME}/.dlt/secrets.toml:/app/.dlt/secrets.toml:ro
 
   # These environment variables can also be set inside the ~/.dlt/config.toml file
   # and act as an example. Configuring openhound can be done using environment variables,


### PR DESCRIPTION
This PR adds a mount for the `secrets.toml` to the example `docker-compose.yml` file. This mount is required to function properly and is currently causing issues for people following our installation documentation.

Fixes [BED-9657](https://specterops.atlassian.net/browse/BED-9657)

[BED-9657]: https://specterops.atlassian.net/browse/BED-9657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * The shared scheduler configuration now securely provides the local secrets file to the application in read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->